### PR TITLE
Remove hover color effects from UI components

### DIFF
--- a/src/components/user/HeroSection.jsx
+++ b/src/components/user/HeroSection.jsx
@@ -123,7 +123,7 @@ const HeroSection = () => {
                         <div className="grid grid-cols-1 md:grid-cols-3 gap-12 max-w-7xl mx-auto text-center">
                             {/* Emotional Healing */}
                             <div className="space-y-4 group cursor-pointer">
-                                <div className="w-20 h-20 mx-auto flex items-center justify-center rounded-full bg-[#C2B6C1] group-hover:bg-[#814E7A] transition-colors duration-300">
+                                <div className="w-20 h-20 mx-auto flex items-center justify-center rounded-full bg-[#C2B6C1]  transition-colors duration-300">
                                     {/* icon */}
                                     <svg
                                         xmlns="http://www.w3.org/2000/svg"
@@ -152,7 +152,7 @@ const HeroSection = () => {
 
                             {/* Clarity & Purpose */}
                             <div className="space-y-4 group cursor-pointer">
-                                <div className="w-20 h-20 mx-auto flex items-center justify-center rounded-full bg-[#C2B6C1] group-hover:bg-[#814E7A] transition-colors duration-300">
+                                <div className="w-20 h-20 mx-auto flex items-center justify-center rounded-full bg-[#C2B6C1]  transition-colors duration-300">
                                     {/* icon */}
                                     <svg
                                         xmlns="http://www.w3.org/2000/svg"
@@ -185,7 +185,7 @@ const HeroSection = () => {
 
                             {/* Spiritual Connection */}
                             <div className="space-y-4 group cursor-pointer">
-                                <div className="w-20 h-20 mx-auto flex items-center justify-center rounded-full bg-[#C2B6C1] group-hover:bg-[#814E7A] transition-colors duration-300">
+                                <div className="w-20 h-20 mx-auto flex items-center justify-center rounded-full bg-[#C2B6C1]  transition-colors duration-300">
                                     {/* icon */}
                                     <svg
                                         xmlns="http://www.w3.org/2000/svg"

--- a/src/components/user/HowItWorks.jsx
+++ b/src/components/user/HowItWorks.jsx
@@ -67,7 +67,7 @@ const HowItWorks = () => {
                             <div
                                 key={step.id}
                                 ref={stepRef}
-                                className={`relative text-center group cursor-pointer p-6 rounded-xl hover:bg-white/50  transform transition-all duration-700 ease-in-out delay-${
+                                className={`relative text-center group cursor-pointer p-6 rounded-xl  transform transition-all duration-700 ease-in-out delay-${
                                     index * 200
                                 } ${
                                     stepVisible
@@ -77,7 +77,7 @@ const HowItWorks = () => {
                             >
                                 {/* Step Number */}
                                 <div className="mb-4 md:mb-6">
-                                    <span className="text-4xl md:text-5xl lg:text-6xl font-bold text-[#5B2655] group-hover:text-[#814E7A] transition-colors duration-300">
+                                    <span className="text-4xl md:text-5xl lg:text-6xl font-bold text-[#5B2655]  transition-colors duration-300">
                                         {step.number}
                                     </span>
                                 </div>


### PR DESCRIPTION
Eliminated group-hover color transitions from icon backgrounds in HeroSection and step numbers in HowItWorks for a more consistent appearance. Hover-based color changes are no longer applied to these elements.